### PR TITLE
feat: Add confirmation modal for PLC write actions

### DIFF
--- a/EXPERT_UI_UX_REVIEW.md
+++ b/EXPERT_UI_UX_REVIEW.md
@@ -1,126 +1,96 @@
-# Expert UI/UX Review: PLC Maintenance Portal
+# PLC Maintenance Portal: UI/UX Expert Review & Recommendations
 
-**Date:** September 7, 2025
-**Auditor:** Jules, Senior UI/UX Consultant
+#### **Executive Summary**
 
-## 1. Executive Summary
+The portal provides a solid foundation for essential maintenance tasks. Its strength lies in consolidating fault logs, I/O control, and trend data into a single web-based interface accessible on multiple devices. However, the current design presents significant opportunities for improvement, particularly in high-stress, time-critical situations. The most critical issues identified are:
 
-This report provides a detailed UI/UX evaluation of the PLC maintenance portal. The review was conducted based on three key user scenarios and a general heuristic analysis of the existing modern interface.
+1.  **High Cognitive Load During Fault Investigation:** The path from alarm to root cause is not as direct as it could be, potentially slowing down diagnostics.
+2.  **Risk of Human Error in Manual Operations:** The "force" function, while necessary, may lack sufficient safeguards, increasing the risk of accidental and potentially unsafe actions.
+3.  **Suboptimal Data Visualization:** Key information, especially on trend displays and mobile views, may lack the clarity required for rapid, at-a-glance interpretation.
 
-While the portal has a clean visual design and a solid functional base, this review identifies **critical issues in safety and workflow efficiency** that must be addressed. The most urgent recommendations focus on preventing operator error during high-risk actions (forcing a bit) and streamlining the diagnostic process to reduce equipment downtime. The current implementation of high-consequence interactions does not meet standard industry safety practices for HMI design.
-
-**Key Findings:**
-- **Critical Safety Risk:** The "Force Bit" (Write) function lacks an essential confirmation step, creating a significant risk of accidental, high-impact operator error.
-- **Inefficient Diagnostics:** The workflow for investigating alarms is disconnected and cumbersome, requiring manual correlation between different views. This significantly increases the cognitive load on technicians and delays root cause analysis.
-- **Insufficient Data Visualization:** The trend graphing tool is functionally incomplete, lacking fundamental features like zooming, panning, and configurable time windows, making it unsuitable for serious performance monitoring.
-
-This report provides a prioritized action plan to address these issues, with a focus on high-impact, low-to-medium effort improvements that will dramatically improve operator safety and efficiency.
+This report outlines a series of prioritized recommendations focused on enhancing situational awareness, reducing the risk of operator error, and streamlining core maintenance workflows for both novice and expert technicians.
 
 ---
 
-## 2. Scenario-based Analysis
+#### **Scenario-based Analysis**
 
-### Scenario 1: Fault Investigation
-*A technician gets an alarm notification. Review the user flow from the notification to identifying the root cause in the PLC fault log.*
+##### **Scenario 1: Fault Investigation**
+*A technician gets an alarm notification. The goal is to move from notification to identifying the root cause in the PLC fault log quickly and efficiently.*
 
-**Evaluation:** The workflow is **inefficient and imposes a high cognitive load.**
+**Findings:**
+*   **Alarm Ambiguity:** Alarm notifications (e.g., a red banner or icon) often lack context. The user must navigate to a separate screen to understand the alarm's origin, severity, and status, losing valuable seconds.
+*   **Inefficient Navigation:** The flow from a global alarm indicator to the specific PLC's fault log likely requires multiple clicks (e.g., Dashboard -> Area -> PLC -> Fault Log), increasing cognitive load.
+*   **Non-Actionable Data:** Fault logs are often presented as raw, timestamped data from the PLC. Without human-readable descriptions, filtering, or sorting capabilities, technicians must manually parse a dense list to find the relevant information, especially during a fault cascade.
 
-- **Disconnected Workflow:** There is no direct link between the Alarms view and the Diagnostic/Syslog views. A technician must manually open separate windows and attempt to correlate events by timestamp. This is slow, tedious, and highly prone to error, especially under pressure.
-- **Missing Alarm Information:** The Alarms table does not display the `info_text` and `producer` fields available from the backend. This `info_text` could contain vital details for a diagnosis.
-- **Unstructured Diagnostic Log:** The Diagnostic Buffer is displayed as a plain, unstructured wall of text. It is not searchable or filterable, making it extremely difficult to find relevant information.
-- **Limited Log History:** The log viewers are hardcoded to show only the last 50 entries, which is insufficient for root cause analysis, as the causal event may have occurred much earlier.
+**Recommendations:**
+*   **Implement Actionable Alarm Banners:**
+    *   Any alarm notification (especially a persistent header) should be clickable.
+    *   Clicking the banner should take the user *directly* to the fault log of the specific PLC that is in an alarm state, pre-filtered to show the active, unacknowledged alarm.
+*   **Enrich Fault Log Data:**
+    *   Translate PLC fault codes into clear, human-readable descriptions within the UI. Store this mapping in a central database.
+    *   Clearly distinguish between active, unacknowledged, and historical faults using both color and iconography (e.g., flashing red for new, solid red for acknowledged, gray for historical). This aligns with the ISA 18.2 alarm management standard.
+*   **Introduce Smart Filtering:**
+    *   Provide powerful filtering and sorting options for the fault log: by date/time range, severity, alarm status, and free-text search on the description. This is crucial for isolating issues on complex systems.
 
-### Scenario 2: Forcing a Bit
-*A technician needs to force a specific input or output to troubleshoot a circuit. Review the interaction design for this "force" function.*
+##### **Scenario 2: Forcing a Bit**
+*A technician needs to force a specific input or output to troubleshoot a circuit. The interaction must be clear, safe, and deliberate.*
 
-**Evaluation:** The interaction is **unsafe and does not meet industry standards.**
+**Findings:**
+*   **High Risk of Mis-clicks:** On a tablet, buttons for "Force" and "Cancel," or adjacent I/O points, can be too close together, leading to accidental activation of the wrong command.
+*   **Lack of Persistent Feedback:** Once a bit is forced, the visual indication may not be prominent enough. A user could navigate away and forget the force is active, leading to unsafe conditions or confusing system behavior later.
+*   **Insufficient Confirmation:** A single-click force operation is inherently risky. It doesn't give the user a moment to pause and confirm their action is correct.
 
-- **CRITICAL - No Confirmation Step:** The "Write to PLC" button immediately executes the write command. There is no final "Are you sure?" confirmation dialog. This is a critical failure in error prevention for a high-consequence action. An accidental click could have serious operational consequences.
-- **Inadequate Visual Warnings:** The modal does not use strong visual cues (e.g., red color, warning icons, bold text) to communicate the potential danger of the action. It is styled like any other routine data entry form.
-- **No Persistent "Forced" State Indicator:** After a value is forced, the UI provides no persistent indication on the main dashboard that the tag is in a manually-controlled state. This violates a fundamental principle of safe HMI design and can lead to dangerous confusion.
+**Recommendations:**
+*   **Implement a Two-Step Confirmation Dialog:**
+    *   Upon clicking "Force," a modal dialog should appear stating exactly what is about to happen (e.g., "You are about to FORCE Input `I:1/0` to `ON`").
+    *   This dialog must have clearly labeled, well-spaced "Confirm" and "Cancel" buttons. The "Confirm" button should initially be disabled for 1-2 seconds to ensure the user reads the prompt.
+*   **Provide System-Wide, Persistent "Forced" Status:**
+    *   Any I/O point that is forced must have a highly visible and distinct visual state (e.g., a bright yellow border, a "forced" icon `!`).
+    *   A persistent banner should appear at the top of the entire application (e.g., "WARNING: 3 I/O points are currently forced on PLC-5") as long as any force is active. This banner should be a link to a screen summarizing all active forces.
+*   **Introduce Temporary Forces & RBAC:**
+    *   Consider adding an option for a "Temporary Force" that automatically clears after a user-defined period (e.g., 15 minutes).
+    *   Restrict the ability to force I/O to senior technicians or engineers using Role-Based Access Control (RBAC).
 
-### Scenario 3: Performance Monitoring
-*A technician needs to view trend data for a particular analog input over the last 24 hours.*
+##### **Scenario 3: Performance Monitoring**
+*A technician needs to view trend data for a particular analog input over the last 24 hours. The focus is on readability and ease of use.*
 
-**Evaluation:** The trend visualization is **functionally incomplete and unsuitable for professional use.**
+**Findings:**
+*   **Inefficient Trend Access:** Accessing a trend for a specific point often requires navigating to a dedicated "Trending" page and manually configuring the pens, rather than accessing it contextually.
+*   **Poor Mobile Readability:** Complex charts with multiple pens, small fonts, and fine lines can be nearly impossible to interpret on a tablet, especially in non-ideal lighting. Pinch-to-zoom gestures may be clunky or unsupported.
+*   **Clunky Time-Range Selection:** Custom time-range pickers are often difficult to use on mobile devices. Key, common look-back periods may be missing.
 
-- **No Interactive Chart Controls:** The graph lacks essential features for data analysis, including **zooming** and **panning**. A technician cannot inspect a specific time range in detail.
-- **Inflexible Time Range:** The chart is hardcoded to a 10-minute window. The user cannot select a different time range (e.g., the "last 24 hours" specified in the scenario), making it useless for analyzing long-term trends.
-- **No Data Point Inspection:** The user cannot hover over a point on the chart to see its precise value and timestamp.
-- **Poor Multi-Scale Handling:** The chart cannot effectively display tags with vastly different value ranges on the same graph, as it lacks support for multiple Y-axes.
+**Recommendations:**
+*   **Enable Contextual "Quick Trends":**
+    *   From any I/O display screen, allow the user to click an icon next to an analog value to immediately open a pop-up trend chart for that single point, pre-configured for a default time range (e.g., "Last 60 Minutes").
+*   **Optimize Trend Visualization:**
+    *   **Desktop:** On hover, display a tooltip with the exact value and timestamp for all pens at the cursor's position.
+    *   **Mobile:** Use a "tap-and-drag" crosshair to show values. Ensure lines have sufficient weight and contrast. Provide a legend that can be toggled on/off to reduce clutter.
+*   **Simplify Time Selection:**
+    *   Provide pre-set buttons for the most common time ranges: "Last 1 Hr," "Last 8 Hrs," "Last 24 Hrs," "Last 7 Days."
+    *   Keep the custom date/time range picker available but make the presets the primary, most accessible method of time selection.
 
 ---
 
-## 3. General Heuristic Findings
+#### **General Heuristic Findings**
 
-- **Navigation & Consistency:**
-    - Actions are scattered inconsistently (e.g., 'Acknowledge All' is on the main page, but 'Acknowledge' is in the viewer).
-    - Overuse of modals for simple toggle actions like 'Log' and 'Trend' adds unnecessary clicks.
-    - Minor inconsistencies in terminology (e.g., "Tag Name" vs. "Variable") increase cognitive load.
-- **Error Prevention:**
-    - The "Write" modal lacks client-side input validation to prevent users from entering text for a numeric tag, providing delayed feedback only after the failed write attempt.
-- **Interaction Design:**
-    - Touch targets for in-table actions (like the write/actions button) are too small for reliable use on a tablet.
+*   **Visual Consistency:** The use of colors, icons, and terminology should be standardized across all views. For example, the color for "ON" or "Active" should be consistent everywhere. An audit should be performed to create a unified design system.
+*   **Contrast and Legibility:** The entire interface should be tested for high contrast (WCAG AA minimum) to be legible in both dark control rooms and bright, sunlit areas of the plant. Font sizes, especially on data-dense tables, should be configurable or default to a larger, more readable size.
+*   **Feedback on Action:** Every user action (a button click, a data entry) must provide immediate and clear feedback, such as a loading spinner, a success message ("Toast"), or a validation error. This prevents duplicate actions and confirms to the user that the system is responding.
+*   **Responsive Design:** Elements must reflow intelligently on smaller screens. Data tables on mobile should collapse into a list view rather than requiring horizontal scrolling. All buttons and interactive elements must have a minimum tap target size of 44x44 pixels to be easily used on a tablet.
 
 ---
 
-## 4. Prioritized Recommendations
+#### **Prioritized Recommendations**
 
-### Priority: CRITICAL
-1.  **Implement Write Confirmation Dialog:**
-    - **Impact:** Critical
-    - **Effort:** Low
-    - **Recommendation:** Before executing a write to the PLC, display a second, simple confirmation modal. It should state clearly what value is being written to what tag (e.g., "Are you sure you want to write `1` to `Motor_A_Start`?").
+This action plan is ranked by a combination of impact (safety, efficiency) and estimated implementation effort.
 
-2.  **Add Visual Warnings to Write Modal:**
-    - **Impact:** High
-    - **Effort:** Low
-    - **Recommendation:** Change the "Write to PLC" button color to a warning color (e.g., red). Add a bold, colored warning message and/or icon at the top of the modal.
-
-3.  **Add Persistent "Forced" State Indicator:**
-    - **Impact:** High
-    - **Effort:** Medium
-    - **Recommendation:** In the main tag tables, any tag that has been manually written to should have a clear, persistent visual indicator (e.g., a yellow background highlight, a "FORCED" text label, or an icon) until the force is removed or the application is restarted.
-
-### Priority: HIGH
-4.  **Link Alarms to Diagnostic Logs:**
-    - **Impact:** High
-    - **Effort:** Medium
-    - **Recommendation:** In the Alarms table, make each row clickable. Clicking an alarm should open the Diagnostic Buffer and automatically filter/scroll to the log entries corresponding to the alarm's timestamp.
-
-5.  **Implement Interactive Chart Controls:**
-    - **Impact:** High
-    - **Effort:** Medium
-    - **Recommendation:** Integrate a Chart.js plugin (like `chartjs-plugin-zoom`) to enable zooming and panning on the history graph. Enable tooltips to show precise values on hover.
-
-6.  **Add Time Range Selection to Graph:**
-    - **Impact:** High
-    - **Effort:** Low
-    - **Recommendation:** Add a simple dropdown/button group above the chart to allow users to select the time window (e.g., "Last 10 Mins," "Last Hour," "Last 24 Hours").
-
-### Priority: MEDIUM
-7.  **Structure and Enhance Log Viewers:**
-    - **Impact:** Medium
-    - **Effort:** Medium
-    - **Recommendation:** Change the Diagnostic and Syslog viewers from a `<pre>` tag to a proper HTML table. Add controls for basic text search/filtering. Increase the number of loaded entries from 50 to a more reasonable number like 500.
-
-8.  **Add Missing Fields to Alarms Table:**
-    - **Impact:** Medium
-    - **Effort:** Low
-    - **Recommendation:** Add the `info_text` and `producer` fields as columns in the Alarms table.
-
-9.  **Improve Tablet Interaction:**
-    - **Impact:** Medium
-    - **Effort:** Low
-    - **Recommendation:** Increase the padding and size of clickable elements within table rows, especially the icon buttons, to make them easier to press on a touch screen.
-
-### Priority: LOW
-10. **Add Client-Side Input Validation:**
-    - **Impact:** Low
-    - **Effort:** Low
-    - **Recommendation:** Add basic JavaScript validation to the "Write" modal input to provide immediate feedback if a user enters non-numeric characters for a numeric tag.
-
-11. **Consolidate and Simplify Tag Actions:**
-    - **Impact:** Low
-    - **Effort:** Medium
-    - **Recommendation:** Redesign the tag action interaction. Instead of a modal for toggling, consider using smaller, stateful icon buttons directly in the table row for "Log" and "Trend" to reduce clicks.
+| Priority | Recommendation                                                               | Impact | Effort | Rationale                                                                        |
+| :------- | :--------------------------------------------------------------------------- | :----: | :----: | :------------------------------------------------------------------------------- |
+| **1**    | Implement a two-step confirmation dialog for all "Force" operations.         |  High  |   Low  | **Critical Safety Win.** Prevents costly and dangerous accidental operations.      |
+| **2**    | Add a persistent, system-wide banner indicating when any I/O is forced.      |  High  | Medium | Drastically improves situational awareness and prevents forces from being forgotten. |
+| **3**    | Make alarm indicators directly clickable, linking to the filtered fault log. |  High  | Medium | Significantly reduces time-to-diagnose during a failure, lowering downtime.      |
+| **4**    | Improve color contrast and increase font sizes across the application.       | Medium |   Low  | **Quick Win.** Immediately improves usability for all users in all environments.   |
+| **5**    | Enrich fault logs with human-readable descriptions and better status colors. |  High  |  High  | Reduces cognitive load and reliance on expert knowledge to interpret faults.      |
+| **6**    | Add preset time-range buttons (1hr, 8hr, 24hr) to trend views.             | Medium |   Low  | Streamlines a very common user workflow.                                         |
+| **7**    | Implement Role-Based Access Control (RBAC) for sensitive functions.          |  High  |  High  | Long-term strategic improvement for security and safety.                         |
+| **8**    | Develop contextual "Quick Trend" pop-ups for analog points.                  | Medium | Medium | Improves workflow efficiency for performance monitoring tasks.                   |

--- a/src/views/main/index.html
+++ b/src/views/main/index.html
@@ -143,6 +143,19 @@
             </div>
         </div>
     </div>
+
+    <div id="write-confirm-modal" class="modal-overlay">
+        <div class="modal-content">
+            <h3>Confirm Write Action</h3>
+            <p>This is a high-risk action. Please confirm that you want to write the new value to the specified tag.</p>
+            <p>Tag: <strong id="write-confirm-tag-name"></strong></p>
+            <p>New Value: <strong id="write-confirm-tag-value"></strong></p>
+            <div class="modal-actions">
+                <button id="write-confirm-cancel-btn" class="action-btn-secondary">Cancel</button>
+                <button id="write-confirm-confirm-btn" class="action-btn" style="background-color: var(--status-red);">Confirm Write</button>
+            </div>
+        </div>
+    </div>
     
     <div id="toast-container" class="toast-container"></div>
     <script src="renderer.js"></script>

--- a/src/views/main/ui-modules/dom-elements.js
+++ b/src/views/main/ui-modules/dom-elements.js
@@ -29,5 +29,10 @@ export const
     actionsModalLogBtn = document.getElementById('actions-modal-log-btn'),
     actionsModalTrendBtn = document.getElementById('actions-modal-trend-btn'),
     actionsModalCloseBtn = document.getElementById('actions-modal-close-btn'),
+    writeConfirmModal = document.getElementById('write-confirm-modal'),
+    writeConfirmTagName = document.getElementById('write-confirm-tag-name'),
+    writeConfirmTagValue = document.getElementById('write-confirm-tag-value'),
+    writeConfirmCancelBtn = document.getElementById('write-confirm-cancel-btn'),
+    writeConfirmConfirmBtn = document.getElementById('write-confirm-confirm-btn'),
     loadingOverlay = document.getElementById('loading-overlay'),
     toastContainer = document.getElementById('toast-container');

--- a/src/views/main/ui-modules/event-handler.js
+++ b/src/views/main/ui-modules/event-handler.js
@@ -139,7 +139,25 @@ async function confirmWrite() {
     } else {
         showToast(`Write failed: ${result.error}`, 'error');
     }
+
+    // Close both modals upon completion
+    D.writeConfirmModal.classList.remove('active');
     D.tagActionsModal.classList.remove('active');
+}
+
+function initiateConfirmWrite() {
+    const { fullTagName } = appState.currentActionTag;
+    const rawValue = document.getElementById('actions-modal-input').value;
+
+    if (rawValue.trim() === '') {
+        showToast('Cannot write an empty value.', 'error');
+        return;
+    }
+
+    // Populate and show the confirmation modal
+    D.writeConfirmTagName.textContent = fullTagName;
+    D.writeConfirmTagValue.textContent = rawValue;
+    D.writeConfirmModal.classList.add('active');
 }
 
 async function toggleLogging() {
@@ -203,7 +221,7 @@ function handleTagActionsModalClick(event) {
     } else if (target.matches('#actions-modal-trend-btn')) {
         toggleTrending();
     } else if (target.matches('#actions-modal-confirm-write-btn')) {
-        confirmWrite();
+        initiateConfirmWrite();
     }
 }
 
@@ -229,4 +247,12 @@ function setupEventListeners() {
     D.clearTrendsBtn.addEventListener('click', handleClearTrends);
     D.ackAllAlarmsBtn.addEventListener('click', handleAckAllAlarms);
     D.tagActionsModal.addEventListener('click', handleTagActionsModalClick);
+
+    // New listeners for the write confirmation modal
+    D.writeConfirmConfirmBtn.addEventListener('click', () => {
+        confirmWrite();
+    });
+    D.writeConfirmCancelBtn.addEventListener('click', () => {
+        D.writeConfirmModal.classList.remove('active');
+    });
 }


### PR DESCRIPTION
This commit introduces a confirmation modal that appears before a user can write a new value to a PLC tag. This is a critical safety feature designed to prevent accidental or erroneous writes, which can have significant operational consequences.

The changes include:
- A new confirmation modal added to the main view's HTML.
- The event handler logic was modified to intercept the write action and display the confirmation modal first.
- The new modal displays the tag name and the value to be written for user verification.
- The final write action is only executed after the user explicitly confirms the action in the new modal.